### PR TITLE
Remove the time limit the pause button is paused for

### DIFF
--- a/humans-proj/src/pages/home/Home.js
+++ b/humans-proj/src/pages/home/Home.js
@@ -79,7 +79,6 @@ export default function Home() {
             }, 1000);
         } else if (!isActive && seconds !== 0) {
             clearInterval(interval);
-            setTimeout(() => toggle(), 20000)
         }
         return () => clearInterval(interval);
     }, [isActive, seconds]);


### PR DESCRIPTION
The pause button would intentionally unpause after 20 seconds. This feature has been removed. The pause button will be paused until clicked.