### PR TITLE
[#82] Timezone display on time

### DIFF
--- a/humans-proj/src/pages/home/Home.js
+++ b/humans-proj/src/pages/home/Home.js
@@ -152,7 +152,7 @@ export default function Home() {
                             <footer id="non-mobile-design-home">
                                 {/* TIME */}
                                 <div id="footer-time">
-                                    <p>{time.format('HH:mm:ss')}<br />{"EST: " + time.format('L')}</p>
+                                    <p>{new Date().toLocaleTimeString('en-us',{timeZoneName:'short'}).split(' ')[2] + ": " + time.format('HH:mm:ss')}<br />{time.format('L')}</p>
                                 </div>
 
                                 {/* LEARN MORE */}


### PR DESCRIPTION
Shifted time zone identifier to be displayed next to the time and not next to the date.
Also updated the time zone display to match whatever time zone the user is in.